### PR TITLE
Unhardcode launcher icon file type

### DIFF
--- a/desktop/ksnip.desktop
+++ b/desktop/ksnip.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Exec=ksnip
-Icon=ksnip.png
+Icon=ksnip
 Terminal=false
 Name=ksnip
 GenericName=ksnip Screenshot Tool


### PR DESCRIPTION
Since you install the icon to a location compliant with [freedesktop.org standards](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) you don't need to specify the icon file extension in the ``.desktop`` launcher. It will be found anyway.

This facilitates the use of non-PNG (e.g. SVG) app icon themes.
Cf. this [example ``.desktop`` launcher](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#example).