### PR TITLE
Use GNUInstallDirs to determine install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,14 @@ endif()
 
 set(KSNIP_VERSION "${PROJECT_VERSION}${KSNIP_VERSION_SUFIX}")
 
+include(GNUInstallDirs)
+
 if (WIN32)
 	set(KSNIP_LANG_INSTAL_DIR "translations")
 elseif (APPLE)
 	set(KSNIP_LANG_INSTAL_DIR "../Resources")
 elseif (UNIX)
-	set(KSNIP_LANG_INSTAL_DIR "/usr/share/ksnip/translations")
+	set(KSNIP_LANG_INSTAL_DIR "${CMAKE_INSTALL_DATAROOTDIR}/ksnip/translations")
 endif ()
 
 configure_file(src/BuildConfig.h.in ${CMAKE_CURRENT_BINARY_DIR}/src/BuildConfig.h)

--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Add metadata file
 
 if(UNIX AND NOT APPLE)
-    install(PROGRAMS ksnip.desktop DESTINATION /usr/share/applications)
-    install(FILES ksnip.svg DESTINATION /usr/share/pixmaps)
-    install(FILES ksnip.appdata.xml DESTINATION /usr/share/metainfo)
+    install(PROGRAMS ksnip.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
+    install(FILES ksnip.svg DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pixmaps)
+    install(FILES ksnip.appdata.xml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,7 +124,7 @@ elseif(WIN32)
 endif ()
 
 if (UNIX AND NOT APPLE)
-	install(TARGETS ksnip RUNTIME DESTINATION /usr/bin)
+	install(TARGETS ksnip RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 	
     # uninstall target
     if(NOT TARGET uninstall)


### PR DESCRIPTION
The current install Paths ignore e.g. CMAKE_INSTALL_PREFIX and are
hardcoded, this allows easy install path manipulation by just passing
the needed values to cmake and not having to patch the build files